### PR TITLE
Refactor to a single Zuul filter

### DIFF
--- a/src/main/java/net/apnic/rdap/error/filters/ZuulErrorFilter.java
+++ b/src/main/java/net/apnic/rdap/error/filters/ZuulErrorFilter.java
@@ -24,9 +24,7 @@ import org.springframework.http.HttpStatus;
 /**
  * Zuul filter for handling errors.
  */
-public class ZuulErrorFilter
-    extends ZuulFilter
-{
+public class ZuulErrorFilter {
     private static final String SEND_ERROR_FILTER_RAN = "sendErrorFilter.ran";
 
     private RDAPObjectFactory rdapObjectFactory = null;
@@ -41,42 +39,8 @@ public class ZuulErrorFilter
         return ExceptionUtils.indexOfThrowable(th, clazz) != -1;
     }
 
-    /**
-     * {@inheritDocs}
-     */
-    @Override
-    public String filterType()
+    public Object run(RequestContext context)
     {
-        return FilterConstants.ERROR_TYPE;
-    }
-
-    /**
-     * {@inheritDocs}
-     */
-    @Override
-    public int filterOrder()
-    {
-        return -1;
-    }
-
-    /**
-     * {@inheritDocs}
-     */
-    @Override
-    public boolean shouldFilter()
-    {
-        RequestContext context = RequestContext.getCurrentContext();
-        return context.getThrowable() != null
-            && context.getBoolean(SEND_ERROR_FILTER_RAN, false) == false;
-    }
-
-    /**
-     * {@inheritDocs}
-     */
-    @Override
-    public Object run()
-    {
-        RequestContext context = RequestContext.getCurrentContext();
         Throwable throwable = context.getThrowable();
 
         if(causedBy(throwable, MalformedRequestException.class))

--- a/src/main/java/net/apnic/rdap/filter/filters/RDAPPathRouteFilter.java
+++ b/src/main/java/net/apnic/rdap/filter/filters/RDAPPathRouteFilter.java
@@ -17,9 +17,7 @@ import net.apnic.rdap.resource.ResourceNotFoundException;
 
 import org.springframework.cloud.netflix.zuul.filters.support.FilterConstants;
 
-public abstract class RDAPPathRouteFilter
-    extends ZuulFilter
-{
+public abstract class RDAPPathRouteFilter {
     private Directory directory = null;
 
     public RDAPPathRouteFilter(Directory directory)
@@ -27,13 +25,11 @@ public abstract class RDAPPathRouteFilter
         this.directory = directory;
     }
 
-    @Override
     public int filterOrder()
     {
         return 1;
     }
 
-    @Override
     public String filterType()
     {
         return FilterConstants.ROUTE_TYPE;
@@ -44,15 +40,14 @@ public abstract class RDAPPathRouteFilter
         return directory;
     }
 
-    public RDAPRequestPath getRDAPRequestPath()
+    public RDAPRequestPath getRDAPRequestPath(RequestContext context)
     {
-        RequestContext context = RequestContext.getCurrentContext();
         return (RDAPRequestPath)context.get(RequestContextKeys.RDAP_REQUEST_PATH);
     }
 
-    public boolean shouldFilter()
+    public boolean shouldFilter(RequestContext context)
     {
-        RDAPRequestPath path = getRDAPRequestPath();
+        RDAPRequestPath path = getRDAPRequestPath(context);
         if(path == null)
         {
             return false;
@@ -60,11 +55,9 @@ public abstract class RDAPPathRouteFilter
         return supportedRequestType() == path.getRequestType();
     }
 
-    @Override
-    public Object run()
+    public Object run(RequestContext context)
     {
-        RequestContext context = RequestContext.getCurrentContext();
-        RDAPRequestPath path = getRDAPRequestPath();
+        RDAPRequestPath path = getRDAPRequestPath(context);
 
         try
         {

--- a/src/main/java/net/apnic/rdap/filter/filters/RDAPPreFilter.java
+++ b/src/main/java/net/apnic/rdap/filter/filters/RDAPPreFilter.java
@@ -3,22 +3,29 @@ package net.apnic.rdap.filter.filters;
 import com.netflix.zuul.context.RequestContext;
 import com.netflix.zuul.ZuulFilter;
 
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import net.apnic.rdap.error.filters.ZuulErrorFilter;
 import net.apnic.rdap.filter.config.RequestContextKeys;
 import net.apnic.rdap.filter.RDAPRequestPath;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.netflix.zuul.filters.support.FilterConstants;
 
 /**
  *
  */
-public class RDAPPreFilter
-    extends ZuulFilter
-{
+public class RDAPPreFilter extends ZuulFilter {
     private final Logger LOGGER =
         Logger.getLogger(RDAPPreFilter.class.getName());
+
+    @Autowired
+    List<RDAPPathRouteFilter> routeFilters;
+
+    @Autowired
+    ZuulErrorFilter zuulErrorFilter;
 
     @Override
     public int filterOrder()
@@ -43,11 +50,23 @@ public class RDAPPreFilter
     {
         RequestContext context = RequestContext.getCurrentContext();
 
-        LOGGER.info("request: " + context.getRequest().getRequestURI());
+        try {
+            LOGGER.info("request: " + context.getRequest().getRequestURI());
 
-        RDAPRequestPath path = RDAPRequestPath.createRequestPath(
-                context.getRequest().getRequestURI());
-        context.put(RequestContextKeys.RDAP_REQUEST_PATH, path);
+            RDAPRequestPath path = RDAPRequestPath.createRequestPath(
+                    context.getRequest().getRequestURI());
+            context.put(RequestContextKeys.RDAP_REQUEST_PATH, path);
+
+            for (RDAPPathRouteFilter pathRouteFilter : routeFilters) {
+                if (pathRouteFilter.shouldFilter(context)) {
+                    pathRouteFilter.run(context);
+                }
+            }
+        } catch (Throwable t) {
+            context.setThrowable(t);
+            zuulErrorFilter.run(context);
+        }
+
         return null;
     }
 }


### PR DESCRIPTION
This is what I mean by 1 Zuul filter. It should remove the need for the error handler to untangle the framework exceptions. I've kept the refactoring to a minimum in order keep this PR clear, though I think there are more opportunities, e.g. pass the RDAPRequestPath instead of a Zuul context.